### PR TITLE
Fix Syntax of the requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ tensorboardX
 networkx
 cvbase
 scikit-image
-pillow=6.1
+pillow==6.1
 tqdm


### PR DESCRIPTION
There is a missing `=`in the requirements.txt file which leads to an error while installing. 