### PR TITLE
:bfix: Fix CGAN backward issue

### DIFF
--- a/models/partial_completion_content_cgan.py
+++ b/models/partial_completion_content_cgan.py
@@ -143,15 +143,15 @@ class PartialCompletionContentCGAN(nn.Module):
         loss_dict['adv'] = gen_gan_loss
 
         # update
-        self.optimD.zero_grad()
-        dis_loss.backward()
-        utils.average_gradients(self.netD)
-        self.optimD.step()
-
         self.optim.zero_grad()
         gen_loss.backward()
         utils.average_gradients(self.model)
         self.optim.step()
+        
+        self.optimD.zero_grad()
+        dis_loss.backward()
+        utils.average_gradients(self.netD)
+        self.optimD.step()
 
         return loss_dict
 


### PR DESCRIPTION
This PR fixes Issue #38. Replacing the problematic lines with the following ones works fine:

```python
# update
self.optim.zero_grad()
gen_loss.backward()
utils.average_gradients(self.model)
self.optim.step()

self.optimD.zero_grad()
dis_loss.backward()
utils.average_gradients(self.netD)
self.optimD.step()
```

The issue might have been due to the incorrect order of calculating the gradients and updating the weights. Doing the backward pass for Generator first works well!